### PR TITLE
Fix undefined `server` in retry exhaustion handling

### DIFF
--- a/lib/net/tcp_client/tcp_client.rb
+++ b/lib/net/tcp_client/tcp_client.rb
@@ -476,7 +476,7 @@ module Net
         if respond_to?(:logger)
           logger.error "#retry_on_connection_failure Connection failure: #{e.class}: #{e.message}. Giving up after #{retries} retries"
         end
-        raise ConnectionFailure.new("After #{retries} retries to host '#{server}': #{exc_str}", server, e.cause)
+        raise ConnectionFailure.new("After #{retries} retries to any of #{servers.join(',')}': #{exc_str}", servers, e.cause)
       end
     end
 


### PR DESCRIPTION
Caught an exception this morning because we ran out of retries, and tripped over an error handler that appears to have been overlooked in the change to add multiple-servers support.