### PR TITLE
Update tcp_client.rb to be ruby 3+ compatible

### DIFF
--- a/lib/net/tcp_client/tcp_client.rb
+++ b/lib/net/tcp_client/tcp_client.rb
@@ -88,7 +88,7 @@ module Net
     #   end
     #
     def self.connect(params = {})
-      connection = new(params)
+      connection = new(**params)
       yield(connection)
     ensure
       connection&.close


### PR DESCRIPTION
Ruby 3+ has changed how names params are called.